### PR TITLE
__autarkie_type_id now uses xxhash because u128 type_id is not available as of the latest nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempdir",
+ "twox-hash",
 ]
 
 [[package]]
@@ -1351,8 +1352,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1363,6 +1374,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1394,6 +1415,9 @@ name = "rand_core"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
 
 [[package]]
 name = "rangemap"
@@ -1733,6 +1757,15 @@ name = "tuple_list"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "141fb9f71ee586d956d7d6e4d5a9ef8e946061188520140f7591b668841d502e"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
+dependencies = [
+ "rand 0.9.2",
+]
 
 [[package]]
 name = "typed-builder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,6 @@ version = "0.1.0"
 dependencies = [
  "autarkie_derive",
  "bincode 1.3.3",
- "blake3",
  "clap",
  "colored",
  "criterion",

--- a/autarkie/Cargo.toml
+++ b/autarkie/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4.5.20", features = ["derive"] }
 regex = "1.11.1"
 num-traits = "0.2.19"
 serde_json = "1.0.140"
+twox-hash = "2.1.1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/autarkie/Cargo.toml
+++ b/autarkie/Cargo.toml
@@ -13,7 +13,6 @@ autarkie_derive = {path = "../autarkie_derive", optional = true}
 libafl = {workspace = true}
 libafl_bolts = {workspace = true}
 libafl_targets = {workspace = true}
-blake3 = "1.5.5"
 colored = "3.0.0"
 petgraph = "0.7.1"
 clap = { version = "4.5.20", features = ["derive"] }

--- a/autarkie/src/fuzzer/context.rs
+++ b/autarkie/src/fuzzer/context.rs
@@ -60,7 +60,7 @@ impl Context {
                     }
                 }
             };
-            let hash = blake3::hash(&data);
+            let hash = twox_hash::XxHash64::oneshot(0, &data);
             let path = path.join(hash.to_string());
             if !std::fs::exists(&path).unwrap() {
                 std::fs::write(&path, data).unwrap();
@@ -77,7 +77,7 @@ impl Context {
         } else {
             self.out_dir.join("rendered_corpus")
         };
-        let hash = blake3::hash(&rendered);
+        let hash = twox_hash::XxHash64::oneshot(0, &rendered);
         let path = path.join(hash.to_string());
         if !std::fs::exists(&path).unwrap() {
             // warn that the same input gave new coverage == instability!

--- a/autarkie/src/fuzzer/stages/generate.rs
+++ b/autarkie/src/fuzzer/stages/generate.rs
@@ -41,7 +41,6 @@ where
         manager: &mut EM,
     ) -> Result<(), libafl::Error> {
         let mut metadata = state.metadata_mut::<Context>()?;
-        self.visitor.borrow_mut().type_input_map = metadata.type_input_map.clone();
         metadata.generated_input();
         let Some(generated) = generate(&mut self.visitor.borrow_mut()) else {
             metadata.default_input();

--- a/autarkie/src/lib.rs
+++ b/autarkie/src/lib.rs
@@ -4,7 +4,6 @@
 #[cfg(feature = "autarkie_derive")]
 pub use autarkie_derive::Grammar;
 
-pub use blake3::hash;
 pub use libafl::corpus::CorpusId;
 pub use libafl::executors::ExitKind as LibAFLExitKind;
 pub use libafl::inputs::Input;

--- a/autarkie/src/lib.rs
+++ b/autarkie/src/lib.rs
@@ -24,3 +24,8 @@ pub use serde::*;
 pub mod fuzzer;
 pub use fuzzer::afl;
 pub use fuzzer::libfuzzer;
+
+
+pub fn hash(data: &[u8]) -> u64 {
+    twox_hash::XxHash64::oneshot(0, data)
+}

--- a/autarkie/src/tree.rs
+++ b/autarkie/src/tree.rs
@@ -2,7 +2,7 @@ use crate::{visitor, NodeType, Visitor};
 use serde::de::DeserializeOwned;
 use std::any::TypeId;
 use std::borrow::Cow;
-use std::hash::{Hasher, Hash};
+use std::hash::{Hash, Hasher};
 use std::{
     collections::{BTreeMap, VecDeque},
     marker::PhantomData,

--- a/autarkie/src/tree.rs
+++ b/autarkie/src/tree.rs
@@ -1,12 +1,14 @@
 use crate::{visitor, NodeType, Visitor};
 use serde::de::DeserializeOwned;
+use std::any::TypeId;
 use std::borrow::Cow;
+use std::hash::{Hasher, Hash};
 use std::{
     collections::{BTreeMap, VecDeque},
     marker::PhantomData,
 };
 
-pub type Id = u128;
+pub type Id = u64;
 
 #[derive(Debug)]
 pub enum MutationType<'a> {
@@ -40,7 +42,10 @@ where
 
 
     fn __autarkie_id() -> Id {
-        std::intrinsics::type_id::<Self>()
+        let mut hasher = twox_hash::XxHash64::default();
+        let type_id = std::any::TypeId::of::<Self>();
+        type_id.hash(&mut hasher);
+        hasher.finish()
     }
 
     fn __autarkie_id_name() -> String {

--- a/autarkie/src/visitor.rs
+++ b/autarkie/src/visitor.rs
@@ -42,7 +42,6 @@ pub struct Visitor {
     /// Fields which are serialized by the Fuzz-ed type's instance. Used to save to corpora for splicing
     serialized: Vec<(Vec<u8>, Id)>,
     ty_generate_map: BTreeMap<Id, BTreeMap<GenerateType, BTreeSet<usize>>>,
-    pub type_input_map: HashMap<Id, Vec<PathBuf>>,
     /// State of randomnes
     rng: StdRand,
     has_recursive_types: bool,
@@ -126,22 +125,11 @@ impl Visitor {
         self.depth.iterate
     }
 
-    pub fn rand_asd(&mut self, t: &Id) -> Option<Vec<u8>> {
-        let maybe = self.coinflip_with_prob(0.3);
-        if maybe {
-            return None;
-        }
-        let Some(items) = self.type_input_map.get(t) else {
-            return None;
-        };
-        let items = items.clone();
-        Some(std::fs::read(items.get(self.random_range(0, items.len() - 1)).unwrap()).unwrap())
-    }
     /// This function adds a type to the type map
     pub fn register_ty(&mut self, parent: Option<(Id, String)>, id: (Id, String), variant: usize) {
         self.ty_map_stack.push(id.0.clone());
         // Let's hope we get no collisions!
-        let parent = parent.unwrap_or((u128::MIN, "AutarkieRootFuzzData".to_string()));
+        let parent = parent.unwrap_or((u64::MIN, "AutarkieRootFuzzData".to_string()));
         if !self.ty_map.get(&parent.0).is_some() {
             self.ty_map.insert(
                 parent.0.clone(),
@@ -355,7 +343,6 @@ impl Visitor {
     pub fn new(seed: u64, depth: DepthInfo, string_num: usize) -> Self {
         let mut visitor = Self {
             has_recursive_types: false,
-            type_input_map: HashMap::new(),
             ty_generate_map: BTreeMap::default(),
             ty_name_map: BTreeMap::default(),
             ty_done: BTreeSet::default(),

--- a/autarkie_derive/src/lib.rs
+++ b/autarkie_derive/src/lib.rs
@@ -553,12 +553,7 @@ fn get_field_defs(fields: &[GrammarField]) -> Vec<proc_macro2::TokenStream> {
             // If we do not have a literal attribute, we use the inner generate function of the type.
             if generator.is_none() {
                 generator = Some(quote! {
-                    let #name = if let Some(data) = v.rand_asd(&Self::__autarkie_id()) {        
-                        autarkie::maybe_deserialize(&mut data.as_slice())
-                        
-                    } else {
-                        <#ty>::__autarkie_generate(v, depth, if is_recursive {cur_depth + 1} else {cur_depth}, None)
-                    }?;
+                    let #name = <#ty>::__autarkie_generate(v, depth, if is_recursive {cur_depth + 1} else {cur_depth}, None)?;
                 });
             }
             // this should never happen, cause we either have a literal attribute or not.


### PR DESCRIPTION
Thanks https://github.com/loknop for the reporting the bug!