### PR TITLE
Fix bugs

### DIFF
--- a/autarkie/src/fuzzer/mod.rs
+++ b/autarkie/src/fuzzer/mod.rs
@@ -7,7 +7,7 @@ mod fuzzer;
 mod hooks;
 pub mod libfuzzer;
 pub mod mutators;
-mod stages;
+pub mod stages;
 
 use crate::fuzzer::hooks::rare_share::RareShare;
 use crate::{Input, Node, ToTargetBytes};

--- a/autarkie/src/tree.rs
+++ b/autarkie/src/tree.rs
@@ -446,7 +446,7 @@ where
                 visitor, depth, cur_depth, None,
             )?))
         } else {
-            None
+            Some(None)
         }
     }
 

--- a/autarkie/src/tree.rs
+++ b/autarkie/src/tree.rs
@@ -49,7 +49,7 @@ where
     }
 
     fn __autarkie_id_name() -> String {
-        std::intrinsics::type_name::<Self>().to_string()
+        std::any::type_name::<Self>().to_string()
     }
 
     fn __autarkie_id_tuple() -> (Id, String) {

--- a/autarkie/src/visitor.rs
+++ b/autarkie/src/visitor.rs
@@ -146,6 +146,12 @@ impl Visitor {
                 i.insert(id.0.clone());
             })
             .or_insert(BTreeSet::from_iter([id.0.clone()]));
+
+        // so types without members also get registered
+        if !self.ty_map.contains_key(&id.0) {
+            self.ty_map.insert(id.0.clone(), BTreeMap::new());
+            self.ty_name_map.insert(id.0.clone(), id.1.clone());
+        }
     }
 
     pub fn pop_ty(&mut self) {

--- a/autarkie/src/visitor.rs
+++ b/autarkie/src/visitor.rs
@@ -287,26 +287,19 @@ impl Visitor {
             let r_variants = variants
                 .get(&GenerateType::Recursive)
                 .expect("____q154Wl5zf2");
-            let nr_variants_len = nr_variants.len().saturating_sub(1);
-            let r_variants_len = r_variants.len().saturating_sub(1);
+            let nr_variants_len = nr_variants.len();
+            let r_variants_len = r_variants.len();
             let id = self.rng.between(
                 0,
-                nr_variants_len
+                (nr_variants_len
                     + if consider_recursive_bias {
                         r_variants_len
                     } else {
                         0
-                    },
+                    }).checked_sub(1)?,
             );
-            if id <= nr_variants_len {
-                if let Some(nr_variant) = nr_variants.iter().nth(id) {
-                    (nr_variant.clone(), false)
-                } else {
-                    (
-                        r_variants.iter().nth(id).expect("nd5oh1G2____").clone(),
-                        true,
-                    )
-                }
+            if id < nr_variants_len {
+                (nr_variants.iter().nth(id).expect("nd5oh1G2____").clone(), false)
             } else {
                 (
                     r_variants

--- a/autarkie_derive/src/lib.rs
+++ b/autarkie_derive/src/lib.rs
@@ -83,7 +83,7 @@ pub fn derive_node(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             let node_impl = quote! {
                 impl #impl_generics ::autarkie::Node for #root_name #ty_generics #where_clause {
                     fn __autarkie_generate(v: &mut autarkie::Visitor, depth: &mut usize, cur_depth : usize, settings: Option<autarkie::GenerateSettings>) -> Option<Self> {
-                        let is_recursive = false;
+                        let is_recursive = v.is_recursive(Self::__autarkie_id());
                         #generate
                     }
 

--- a/autarkie_derive/src/lib.rs
+++ b/autarkie_derive/src/lib.rs
@@ -83,7 +83,7 @@ pub fn derive_node(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             let node_impl = quote! {
                 impl #impl_generics ::autarkie::Node for #root_name #ty_generics #where_clause {
                     fn __autarkie_generate(v: &mut autarkie::Visitor, depth: &mut usize, cur_depth : usize, settings: Option<autarkie::GenerateSettings>) -> Option<Self> {
-                        let (_, is_recursive) = v.generate(&Self::__autarkie_id(), cur_depth)?;
+                        let is_recursive = false;
                         #generate
                     }
 


### PR DESCRIPTION
Changes:
- make stages public so they can be used independently of the main fuzzer
- return Some(None) instead of just None when generating an Option since returning None by itself would mean generation failed.
- directly add types to ty_map if they're not present yet as otherwise empty structs aren't registered since they have no members that can register them.
- don't call v.generate for struct generation. Because:
    1. This will always fail for empty structs so they won't be generated at all
    2. This doesn't really make sense for structs as this will just tell us if some random member is recursive but we will generate all of them anyways. Also I'd argue that you can only recurse though enums so this should always be false.
 