### PR TITLE
add Node for boxed str

### DIFF
--- a/autarkie/src/tree.rs
+++ b/autarkie/src/tree.rs
@@ -777,6 +777,18 @@ impl Node for std::string::String {
     }
 }
 
+impl Node for Box<str> {
+    fn __autarkie_generate(
+        visitor: &mut Visitor,
+        depth: &mut usize,
+        cur_depth: usize,
+        settings: Option<GenerateSettings>,
+    ) -> Option<Self> {
+        std::string::String::__autarkie_generate(visitor, depth, cur_depth, settings)
+            .map(std::string::String::into_boxed_str)
+    }
+}
+
 #[cfg(not(feature = "scale"))]
 impl Node for char {
     fn __autarkie_generate(


### PR DESCRIPTION
Hi, awesome project!

I want to use autarkie with structs that contain `Box<str>`, but this fails, as it doesn't implement `Node`:

```rs
error[E0599]: the method `__autarkie_mutate` exists for struct `Box<str>`, but its trait bounds were not satisfied
   --> ...:101:...
    |
101 |   #[derive(autarkie::Grammar,serde::Serialize,serde::Deserialize,Debug, PartialEq, Eq, Hash, Clone)]
    |            ^^^^^^^^^^^^^^^^^ method cannot be called on `Box<str>` due to unsatisfied trait bounds
    |
   ::: .../.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:231:1
    |
231 | / pub struct Box<
232 | |     T: ?Sized,
233 | |     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
234 | | >(Unique<T>, A);
    | |_- doesn't satisfy `Box<str>: autarkie::Node`
    |
    = note: the following trait bounds were not satisfied:
            `str: Sized`
            which is required by `Box<str>: autarkie::Node`
            `str: autarkie::Node`
            which is required by `Box<str>: autarkie::Node`
            `str: Clone`
            which is required by `Box<str>: autarkie::Node`
    = note: this error originates in the derive macro `autarkie::Grammar` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Implementing `Node` for `Box<str>`, reusing the implementation for `String` does the trick.